### PR TITLE
Update PyDrive to 1.3.1 to get latest fixes

### DIFF
--- a/requires.txt
+++ b/requires.txt
@@ -1,2 +1,2 @@
-PyDrive==1.0.1
 validators==0.10
+PyDrive==1.3.1


### PR DESCRIPTION
Link https://github.com/googledrive/PyDrive/issues/78
Fixes `ImportError: cannot import name CredentialsFileSymbolicLinkError`